### PR TITLE
Fix search query clearing on data source change

### DIFF
--- a/feature/search/src/main/java/com/rlad/feature/search/ui/SearchBar.kt
+++ b/feature/search/src/main/java/com/rlad/feature/search/ui/SearchBar.kt
@@ -48,12 +48,12 @@ import com.rlad.feature.search.R
 @Composable
 internal fun SearchBar(
     modifier: Modifier,
+    query: String,
     onQueryChanged: (String) -> Unit,
     onSearchFocusChanged: (Boolean) -> Unit = {},
     onClearQueryClicked: () -> Unit,
     onBackClicked: () -> Unit,
 ) {
-    var query by rememberSaveable { mutableStateOf("") }
     var focused by rememberSaveable { mutableStateOf(false) }
 
     val focusManager = LocalFocusManager.current
@@ -71,7 +71,7 @@ internal fun SearchBar(
                 onClick = {
                     focusManager.clearFocus()
                     keyboardController?.hide()
-                    query = ""
+                    onQueryChanged("")
                     onBackClicked()
                 },
             ) {
@@ -81,16 +81,13 @@ internal fun SearchBar(
 
         SearchTextField(
             query,
-            { newQuery ->
-                query = newQuery
-                onQueryChanged(newQuery)
-            },
+            onQueryChanged,
             { newFocused ->
                 focused = newFocused
                 onSearchFocusChanged(newFocused)
             },
             {
-                query = ""
+                onQueryChanged("")
                 onClearQueryClicked()
             },
             focused,

--- a/feature/search/src/main/java/com/rlad/feature/search/ui/SearchScreen.kt
+++ b/feature/search/src/main/java/com/rlad/feature/search/ui/SearchScreen.kt
@@ -95,6 +95,7 @@ private fun SearchScreenContent(
     onItemCardClicked: (String) -> Unit,
 ) {
     var openBottomSheet by rememberSaveable { mutableStateOf(false) }
+    var searchQuery by rememberSaveable { mutableStateOf("") }
 
     val gridState = rememberLazyGridState()
     val isScrollToTopButtonVisible by remember {
@@ -110,8 +111,15 @@ private fun SearchScreenContent(
                 modifier = Modifier
                     .statusBarsPadding()
                     .windowInsetsPadding(WindowInsets.navigationBars.only(WindowInsetsSides.Horizontal)),
-                onQueryTextChanged = viewModel::onQueryTextChanged,
-                onClearSearchClicked = viewModel::onClearSearchClicked,
+                query = searchQuery,
+                onQueryTextChanged = { newQuery ->
+                    searchQuery = newQuery
+                    viewModel.onQueryTextChanged(newQuery)
+                },
+                onClearSearchClicked = {
+                    searchQuery = ""
+                    viewModel.onClearSearchClicked()
+                },
             )
         },
         floatingActionButton = {
@@ -161,6 +169,10 @@ private fun SearchScreenContent(
                 availableDataSources = viewModel.getAvailableDataSourcesUseCase().collectAsState(initial = emptyList()).value,
                 onDataSourceClicked = { dataSource ->
                     viewModel.onDataSourceClicked(dataSource)
+                    if (searchQuery.isNotEmpty()) {
+                        searchQuery = ""
+                        viewModel.onClearSearchClicked()
+                    }
                     openBottomSheet = false
                 },
             )
@@ -226,11 +238,13 @@ private fun SheetItem(
 @Composable
 private fun SearchBar(
     modifier: Modifier,
+    query: String,
     onQueryTextChanged: (String) -> Unit,
     onClearSearchClicked: () -> Unit,
 ) {
     SearchBar(
         modifier = modifier,
+        query = query,
         onQueryChanged = onQueryTextChanged,
         onClearQueryClicked = onClearSearchClicked,
         onBackClicked = onClearSearchClicked,


### PR DESCRIPTION
## Summary
- keep search text in SearchScreen state
- allow SearchBar to receive external query
- clear search query when changing data sources via bottom sheet

## Testing
- `./gradlew test --stacktrace` *(fails: No route to host)*