### PR TITLE
Update compile & target sdk versions to 36

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,7 +6,7 @@ android {
     namespace = "com.rlad"
 
     defaultConfig {
-        targetSdk = 34
+        targetSdk = 36
         applicationId = "com.rlad"
         versionCode = 1
         versionName = "1.0.0"

--- a/build-logic/src/main/kotlin/GradleConfiguration.kt
+++ b/build-logic/src/main/kotlin/GradleConfiguration.kt
@@ -29,7 +29,7 @@ internal fun Project.configureKotlinAndroid() {
     }
 
     android {
-        compileSdkVersion(34)
+        compileSdkVersion(36)
 
         defaultConfig {
             minSdk = 26


### PR DESCRIPTION
## Summary
- use Android compile SDK 36
- update target SDK to 36

## Testing
- `./gradlew help` *(fails: No route to host)*