### PR TITLE
Add tests for giphy and artic data sources

### DIFF
--- a/core/infrastructure/artic/src/test/java/com/rlad/core/infrastructure/artic/local/ArticLocalDataSourceTest.kt
+++ b/core/infrastructure/artic/src/test/java/com/rlad/core/infrastructure/artic/local/ArticLocalDataSourceTest.kt
@@ -1,0 +1,79 @@
+package com.rlad.core.infrastructure.artic.local
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ArticLocalDataSourceTest {
+
+    private val artworks = listOf(
+        ArtworkEntity(
+            articId = 1,
+            title = "title1",
+            imageId = "img1",
+            artistTitle = "artist1",
+            artistDisplay = "display1",
+            departmentTitle = "department1",
+            placeOfOrigin = "place1",
+            altText = "alt1",
+            dateDisplay = "date1",
+        ),
+        ArtworkEntity(
+            articId = 2,
+            title = "title2",
+            imageId = "img2",
+            artistTitle = "artist2",
+            artistDisplay = "display2",
+            departmentTitle = "department2",
+            placeOfOrigin = "place2",
+            altText = "alt2",
+            dateDisplay = "date2",
+        )
+    )
+
+    private val fakeDao = FakeArtworkDao()
+    private val localDataSource = ArticLocalDataSource(fakeDao)
+
+    @Test
+    fun getArtworkById_returnsStoredArtwork() = runTest {
+        localDataSource.insert(artworks)
+        assertEquals(
+            artworks[1],
+            localDataSource.getById("2").first()
+        )
+    }
+
+    @Test
+    fun getArtworkById_returnsNullWhenMissing() = runTest {
+        localDataSource.insert(artworks)
+        assertEquals(
+            null,
+            localDataSource.getById("10").first()
+        )
+    }
+
+    private class FakeArtworkDao : ArtworkDao {
+        private val storage = mutableListOf<ArtworkEntity>()
+
+        override fun getAll() = object : androidx.paging.PagingSource<Int, ArtworkEntity>() {
+            override fun getRefreshKey(state: androidx.paging.PagingState<Int, ArtworkEntity>): Int? = null
+            override suspend fun load(params: LoadParams<Int>): LoadResult<Int, ArtworkEntity> =
+                LoadResult.Page(storage, prevKey = null, nextKey = null)
+        }
+
+        override fun getById(articId: Int): Flow<ArtworkEntity?> = flow {
+            emit(storage.firstOrNull { it.articId == articId })
+        }
+
+        override suspend fun insert(artworks: List<ArtworkEntity>) {
+            storage.addAll(artworks)
+        }
+
+        override suspend fun clearTable() {
+            storage.clear()
+        }
+    }
+}

--- a/core/infrastructure/artic/src/test/java/com/rlad/core/infrastructure/artic/remote/ArticRemoteDataSourceTest.kt
+++ b/core/infrastructure/artic/src/test/java/com/rlad/core/infrastructure/artic/remote/ArticRemoteDataSourceTest.kt
@@ -1,0 +1,89 @@
+package com.rlad.core.infrastructure.artic.remote
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ArticRemoteDataSourceTest {
+
+    private val artworks = listOf(
+        ServerArtwork(
+            id = 1,
+            title = "title1",
+            imageId = "img1",
+            thumbnail = ServerArtwork.Thumbnail(altText = "alt1"),
+            artistTitle = "artist1",
+            artistDisplay = "display1",
+            placeOfOrigin = "place1",
+            departmentTitle = "department1",
+            dateDisplay = "date1",
+        ),
+        ServerArtwork(
+            id = 2,
+            title = "cool art",
+            imageId = "img2",
+            thumbnail = ServerArtwork.Thumbnail(altText = "alt2"),
+            artistTitle = "artist2",
+            artistDisplay = "display2",
+            placeOfOrigin = "place2",
+            departmentTitle = "department2",
+            dateDisplay = "date2",
+        )
+    )
+
+    private val fakeArticApi = FakeArticApi(artworks)
+    private val remoteDataSource = ArticRemoteDataSource(fakeArticApi)
+
+    @Test
+    fun artworks_allApiItemsAreReturned() = runTest {
+        assertEquals(
+            ServerArtworksRoot(
+                pagination = ServerArtworksRoot.ServerPagination(limit = artworks.size, offset = 0),
+                data = artworks
+            ),
+            remoteDataSource.getRootData(offset = 0, pageSize = 10)
+        )
+    }
+
+    @Test
+    fun search_artworksAreFilteredByQuery() = runTest {
+        assertEquals(
+            ServerArtworksRoot(
+                pagination = ServerArtworksRoot.ServerPagination(limit = 1, offset = 0),
+                data = listOf(artworks[1])
+            ),
+            remoteDataSource.search(query = "cool", offset = 0, pageSize = 10)
+        )
+    }
+
+    @Test
+    fun artwork_itemWithMatchingIdIsReturned() = runTest {
+        assertEquals(
+            artworks[1],
+            remoteDataSource.getItem(id = "2")
+        )
+    }
+
+    private class FakeArticApi(
+        private val artworks: List<ServerArtwork>
+    ) : ArticApi {
+        override suspend fun artworks(from: Int, size: Int): ServerArtworksRoot {
+            return ServerArtworksRoot(
+                pagination = ServerArtworksRoot.ServerPagination(limit = artworks.size, offset = from),
+                data = artworks
+            )
+        }
+
+        override suspend fun artwork(id: String): ServerArtworkRoot {
+            return ServerArtworkRoot(artworks.first { it.id == id.toInt() })
+        }
+
+        override suspend fun search(query: String, from: Int, size: Int): ServerArtworksRoot {
+            val filtered = artworks.filter { it.title.contains(query) }
+            return ServerArtworksRoot(
+                pagination = ServerArtworksRoot.ServerPagination(limit = filtered.size, offset = from),
+                data = filtered
+            )
+        }
+    }
+}

--- a/core/infrastructure/giphy/src/test/java/com/rlad/core/infrastructure/giphy/local/GiphyLocalDataSourceTest.kt
+++ b/core/infrastructure/giphy/src/test/java/com/rlad/core/infrastructure/giphy/local/GiphyLocalDataSourceTest.kt
@@ -1,0 +1,73 @@
+package com.rlad.core.infrastructure.giphy.local
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class GiphyLocalDataSourceTest {
+
+    private val gifs = listOf(
+        GifEntity(
+            giphyId = "1",
+            title = "title1",
+            imageUrl = "image1",
+            username = "user1",
+            importDatetime = "import1",
+            trendingDatetime = "trend1",
+        ),
+        GifEntity(
+            giphyId = "2",
+            title = "title2",
+            imageUrl = "image2",
+            username = "user2",
+            importDatetime = "import2",
+            trendingDatetime = "trend2",
+        )
+    )
+
+    private val fakeDao = FakeGifDao()
+    private val localDataSource = GiphyLocalDataSource(fakeDao)
+
+    @Test
+    fun getGifById_returnsStoredGif() = runTest {
+        localDataSource.insert(gifs)
+        assertEquals(
+            gifs[1],
+            localDataSource.getById("2").first()
+        )
+    }
+
+    @Test
+    fun getGifById_returnsNullWhenMissing() = runTest {
+        localDataSource.insert(gifs)
+        assertEquals(
+            null,
+            localDataSource.getById("10").first()
+        )
+    }
+
+    private class FakeGifDao : GifDao {
+        private val storage = mutableListOf<GifEntity>()
+
+        override fun getAll() = object : androidx.paging.PagingSource<Int, GifEntity>() {
+            override fun getRefreshKey(state: androidx.paging.PagingState<Int, GifEntity>): Int? = null
+            override suspend fun load(params: LoadParams<Int>): LoadResult<Int, GifEntity> =
+                LoadResult.Page(storage, prevKey = null, nextKey = null)
+        }
+
+        override fun getById(giphyId: String): Flow<GifEntity?> = flow {
+            emit(storage.firstOrNull { it.giphyId == giphyId })
+        }
+
+        override suspend fun insert(gifs: List<GifEntity>) {
+            storage.addAll(gifs)
+        }
+
+        override suspend fun clearTable() {
+            storage.clear()
+        }
+    }
+}

--- a/core/infrastructure/giphy/src/test/java/com/rlad/core/infrastructure/giphy/remote/GiphyRemoteDataSourceTest.kt
+++ b/core/infrastructure/giphy/src/test/java/com/rlad/core/infrastructure/giphy/remote/GiphyRemoteDataSourceTest.kt
@@ -1,0 +1,85 @@
+package com.rlad.core.infrastructure.giphy.remote
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class GiphyRemoteDataSourceTest {
+
+    private val gifs = listOf(
+        ServerGif(
+            id = "1",
+            url = "url1",
+            username = "user1",
+            title = "title1",
+            importDatetime = "import1",
+            trendingDatetime = "trending1",
+            images = ServerGif.Images(ServerGif.Images.Image(url = "image1")),
+        ),
+        ServerGif(
+            id = "2",
+            url = "url2",
+            username = "user2",
+            title = "cool",
+            importDatetime = "import2",
+            trendingDatetime = "trending2",
+            images = ServerGif.Images(ServerGif.Images.Image(url = "image2")),
+        )
+    )
+
+    private val fakeGiphyApi = FakeGiphyApi(gifs)
+    private val remoteDataSource = GiphyRemoteDataSource(fakeGiphyApi)
+
+    @Test
+    fun trendingGifs_allApiItemsAreReturned() = runTest {
+        assertEquals(
+            ServerGifsRoot(
+                data = gifs,
+                pagination = ServerPagination(offset = 0, count = gifs.size)
+            ),
+            remoteDataSource.getRootData(offset = 0, pageSize = 10)
+        )
+    }
+
+    @Test
+    fun searchGifs_apiItemsAreFilteredByQuery() = runTest {
+        assertEquals(
+            ServerGifsRoot(
+                data = listOf(gifs[1]),
+                pagination = ServerPagination(offset = 0, count = 1)
+            ),
+            remoteDataSource.search(query = "cool", offset = 0, pageSize = 10)
+        )
+    }
+
+    @Test
+    fun getGif_itemWithMatchingIdIsReturned() = runTest {
+        assertEquals(
+            gifs[1],
+            remoteDataSource.getItem(id = "2")
+        )
+    }
+
+    private class FakeGiphyApi(
+        private val gifs: List<ServerGif>
+    ) : GiphyApi {
+        override suspend fun trendingGifs(apiKey: String, offset: Int, limit: Int): ServerGifsRoot {
+            return ServerGifsRoot(
+                data = gifs,
+                pagination = ServerPagination(offset = offset, count = gifs.size)
+            )
+        }
+
+        override suspend fun searchGifs(apiKey: String, offset: Int, limit: Int, query: String): ServerGifsRoot {
+            val filtered = gifs.filter { it.title.contains(query) }
+            return ServerGifsRoot(
+                data = filtered,
+                pagination = ServerPagination(offset = offset, count = filtered.size)
+            )
+        }
+
+        override suspend fun getGif(gifId: String, apiKey: String): ServerGifRoot {
+            return ServerGifRoot(gifs.first { it.id == gifId })
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for `GiphyRemoteDataSource` and `GiphyLocalDataSource`
- add unit tests for `ArticRemoteDataSource` and `ArticLocalDataSource`
- use fake API and DAO implementations for isolated testing

## Testing
- `./gradlew test` *(fails: No route to host when Gradle tries to download distribution)*