### PR TITLE
Update project READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,56 +1,33 @@
 # RLAD - Random List And Details
 
-RLAD is an Android application that follows development best practices and is used as a playground
-to try out new patterns and libraries in the Android world.
+RLAD is a playground for trying out mobile development patterns in both native Android and React Native. This repository contains two separate apps:
 
-The app uses a few public APIs to display lists of items and their details.
+- **native-android/** – the original Android application written in Kotlin using Jetpack Compose and other modern libraries.
+- **expo/** – a cross‑platform app built with React Native via Expo.
 
-RLAD is available on [Google Play](https://play.google.com/store/apps/details?id=com.rlad).
-
-## Technologies
-
-* Kotlin
-* Coroutines
-* Compose
-* Hilt
-* Room
-* Retrofit
-* Paging
-* Coil
-* Unit testing
-* UI testing
-* Other various Jetpack libraries
-* Modularization
-* Github Actions
-* ...
+Both apps use public APIs to display lists of items and their details. The Android version is available on [Google Play](https://play.google.com/store/apps/details?id=com.rlad).
 
 ## APIs
 
-* [Art Institute of Chicago](https://api.artic.edu)
-* [Giphy](https://developers.giphy.com/docs/api/endpoint)
-* [Rick And Morty](https://rickandmortyapi.com/documentation)
+- [Art Institute of Chicago](https://api.artic.edu)
+- [Giphy](https://developers.giphy.com/docs/api/endpoint)
+- [Rick And Morty](https://rickandmortyapi.com/documentation)
 
-## Development setup
+## Running the native Android app
 
-1. Clone the repository
-2. Generate Giphy API key on [developers.giphy.com](https://developers.giphy.com)
-3. Set the key in `~/.gradle/gradle.properties` as `GIPHY_API_KEY=ThisIsYourKey`
-4. Build the project
+1. Clone the repository.
+2. Generate a Giphy API key on [developers.giphy.com](https://developers.giphy.com).
+3. Add the key to `~/.gradle/gradle.properties` as `GIPHY_API_KEY=YOUR_KEY`.
+4. Open the `native-android` project in Android Studio and build/run it.
 
-## Modularization
+The Android app is modularized into feature and core modules. The dependency graph below illustrates the relationships between modules.
 
 ![dependency-graph](docs/dependency-graph.png)
 
-App is split into feature and core modules. Feature modules correspond to the UI features that
-are visible to the user. Core modules are building blocks used by feature modules.
+## Running the Expo app
 
-Feature modules:
+1. Navigate to the `expo` directory.
+2. Install dependencies with `npm install`.
+3. Start the app with `npx expo start`.
 
-* Search
-* Details
 
-Core modules:
-
-* Domain: UI models, use cases, navigator, etc
-* Infrastructure: usage of external APIs
-* UI: shared components used in UI

--- a/expo/README.md
+++ b/expo/README.md
@@ -1,50 +1,18 @@
-# Welcome to your Expo app 👋
+# RLAD Expo
 
-This is an [Expo](https://expo.dev) project created with [`create-expo-app`](https://www.npmjs.com/package/create-expo-app).
+This folder contains the Expo version of RLAD. See the repository root README for project details.
 
-## Get started
+## Running
 
-1. Install dependencies
+1. Install dependencies:
 
    ```bash
    npm install
    ```
 
-2. Start the app
+2. Start the development server:
 
    ```bash
    npx expo start
    ```
 
-In the output, you'll find options to open the app in a
-
-- [development build](https://docs.expo.dev/develop/development-builds/introduction/)
-- [Android emulator](https://docs.expo.dev/workflow/android-studio-emulator/)
-- [iOS simulator](https://docs.expo.dev/workflow/ios-simulator/)
-- [Expo Go](https://expo.dev/go), a limited sandbox for trying out app development with Expo
-
-You can start developing by editing the files inside the **app** directory. This project uses [file-based routing](https://docs.expo.dev/router/introduction).
-
-## Get a fresh project
-
-When you're ready, run:
-
-```bash
-npm run reset-project
-```
-
-This command will move the starter code to the **app-example** directory and create a blank **app** directory where you can start developing.
-
-## Learn more
-
-To learn more about developing your project with Expo, look at the following resources:
-
-- [Expo documentation](https://docs.expo.dev/): Learn fundamentals, or go into advanced topics with our [guides](https://docs.expo.dev/guides).
-- [Learn Expo tutorial](https://docs.expo.dev/tutorial/introduction/): Follow a step-by-step tutorial where you'll create a project that runs on Android, iOS, and the web.
-
-## Join the community
-
-Join our community of developers creating universal apps.
-
-- [Expo on GitHub](https://github.com/expo/expo): View our open source platform and contribute.
-- [Discord community](https://chat.expo.dev): Chat with Expo users and ask questions.


### PR DESCRIPTION
## Summary
- describe native Android and Expo apps in the root README
- shrink the Expo README to only show how to run the project

## Testing
- `./gradlew help` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_684b2d94f3948321bc7d97b650d6987f