### PR TITLE
Enhance Expo UI

### DIFF
--- a/expo/app/index.tsx
+++ b/expo/app/index.tsx
@@ -10,6 +10,7 @@ import {
   useWindowDimensions,
   View,
 } from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import { DataSourceBottomSheet } from "@/components/DataSourceBottomSheet";
@@ -63,59 +64,64 @@ export default function HomeScreen() {
   );
 
   return (
-    <SafeAreaView
-      className="flex-1"
-      edges={["top", "left", "right"]}
+    <LinearGradient
+      colors={[colors.primary, colors.background]}
+      style={{ flex: 1 }}
     >
-      <SearchBar
-        query={searchQuery}
-        onQueryChanged={onSearchQueryChanged}
-        isFocused={isSearchFocused}
-        onFocused={onSearchFocused}
-        onClearButtonClicked={onClearButtonClicked}
-        onFilterButtonClicked={onFilterButtonClicked}
-      />
+      <SafeAreaView
+        className="flex-1"
+        edges={["top", "left", "right"]}
+      >
+        <SearchBar
+          query={searchQuery}
+          onQueryChanged={onSearchQueryChanged}
+          isFocused={isSearchFocused}
+          onFocused={onSearchFocused}
+          onClearButtonClicked={onClearButtonClicked}
+          onFilterButtonClicked={onFilterButtonClicked}
+        />
 
-      <FlatList
-        data={items}
-        renderItem={renderItem}
-        key={listKey}
-        keyExtractor={(item) => item.id}
-        numColumns={numColumns}
-        contentContainerStyle={{ padding: 8 }}
-        refreshControl={
-          <RefreshControl
-            tintColor={colors.text}
-            progressBackgroundColor={colors.card}
-            colors={[colors.text]}
-            refreshing={isLoading && items.length === 0}
-            onRefresh={onPullToRefresh}
-          />
-        }
-        onEndReached={onLoadMoreItems}
-        onEndReachedThreshold={0.1}
-        ListFooterComponent={
-          isLoading && items.length > 0 ? (
-            <View className="p-4">
-              <ActivityIndicator size="large" />
-            </View>
-          ) : null
-        }
-        ListEmptyComponent={
-          !isLoading ? (
-            <View className="p-8">
-              <Text className="text-center text-lg">No items found</Text>
-            </View>
-          ) : null
-        }
-      />
+        <FlatList
+          data={items}
+          renderItem={renderItem}
+          key={listKey}
+          keyExtractor={(item) => item.id}
+          numColumns={numColumns}
+          contentContainerStyle={{ padding: 8 }}
+          refreshControl={
+            <RefreshControl
+              tintColor={colors.text}
+              progressBackgroundColor={colors.card}
+              colors={[colors.text]}
+              refreshing={isLoading && items.length === 0}
+              onRefresh={onPullToRefresh}
+            />
+          }
+          onEndReached={onLoadMoreItems}
+          onEndReachedThreshold={0.1}
+          ListFooterComponent={
+            isLoading && items.length > 0 ? (
+              <View className="p-4">
+                <ActivityIndicator size="large" />
+              </View>
+            ) : null
+          }
+          ListEmptyComponent={
+            !isLoading ? (
+              <View className="p-8">
+                <Text className="text-center text-lg">No items found</Text>
+              </View>
+            ) : null
+          }
+        />
 
-      <DataSourceBottomSheet
-        isOpen={isBottomSheetOpen}
-        onClose={onBottomSheetClosed}
-        selectedDataSource={selectedDataSource}
-        onDataSourceSelected={onDataSourceSelected}
-      />
-    </SafeAreaView>
+        <DataSourceBottomSheet
+          isOpen={isBottomSheetOpen}
+          onClose={onBottomSheetClosed}
+          selectedDataSource={selectedDataSource}
+          onDataSourceSelected={onDataSourceSelected}
+        />
+      </SafeAreaView>
+    </LinearGradient>
   );
 }

--- a/expo/components/ItemCard.tsx
+++ b/expo/components/ItemCard.tsx
@@ -1,8 +1,10 @@
-import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card } from "@/components/ui/card";
+import { Text } from "@/components/ui/text";
 import { ItemUiModel } from "@/lib/types/uiModelTypes";
 import { Image } from "expo-image";
+import { LinearGradient } from "expo-linear-gradient";
 import React from "react";
-import { TouchableOpacity } from "react-native";
+import { StyleSheet, TouchableOpacity, View } from "react-native";
 
 interface ItemCardProps {
   item: ItemUiModel;
@@ -15,16 +17,26 @@ export function ItemCard({ item, onPress }: ItemCardProps) {
       className="w-1/2 flex-1 p-2"
       onPress={() => onPress(item)}
     >
-      <Card>
-        <Image
-          source={{ uri: item.imageUrl }}
-          style={{ width: "100%", height: 150 }}
-          contentFit="cover"
-        />
-        <CardHeader>
-          <CardTitle className="line-clamp-1">{item.name}</CardTitle>
-          <CardDescription className="line-clamp-1">{item.cardCaption}</CardDescription>
-        </CardHeader>
+      <Card className="overflow-hidden rounded-xl shadow-lg">
+        <View className="relative">
+          <Image
+            source={{ uri: item.imageUrl }}
+            style={{ width: "100%", height: 150 }}
+            contentFit="cover"
+          />
+          <LinearGradient
+            colors={["transparent", "rgba(0,0,0,0.6)"]}
+            style={StyleSheet.absoluteFill}
+          />
+          <View className="absolute bottom-0 left-0 right-0 p-2">
+            <Text className="text-base font-semibold text-card-foreground" numberOfLines={1}>
+              {item.name}
+            </Text>
+            <Text className="text-sm text-card-foreground/80" numberOfLines={1}>
+              {item.cardCaption}
+            </Text>
+          </View>
+        </View>
       </Card>
     </TouchableOpacity>
   );

--- a/expo/components/ItemDetails.tsx
+++ b/expo/components/ItemDetails.tsx
@@ -23,12 +23,21 @@ export function ItemDetails({ item }: { item: ItemUiModel }) {
           style={{ width: "100%", height: "100%" }}
           contentFit="cover"
         />
-
         <View style={{ position: "absolute", bottom: 0, left: 0, right: 0, height: "30%" }}>
           <LinearGradient
-            colors={["transparent", "rgba(0,0,0,0.4)"]}
+            colors={["transparent", "rgba(0,0,0,0.6)"]}
             style={{ flex: 1 }}
           />
+        </View>
+        <View className="absolute bottom-4 left-4 right-4">
+          <Text className="text-2xl font-bold text-card-foreground" numberOfLines={2}>
+            {item.name}
+          </Text>
+          {item.cardCaption ? (
+            <Text className="text-base text-card-foreground/80" numberOfLines={1}>
+              {item.cardCaption}
+            </Text>
+          ) : null}
         </View>
       </View>
 


### PR DESCRIPTION
## Summary
- update item list cards with gradient overlay
- display item name and caption on item details hero image
- add a vibrant gradient background to the home screen

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_b_685b14db96b08321be04ef046da5dacd