### PR TITLE
Enhance Expo UI with gradients and animations

### DIFF
--- a/expo/app/index.tsx
+++ b/expo/app/index.tsx
@@ -11,6 +11,7 @@ import {
   View,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+import { LinearGradient } from "expo-linear-gradient";
 
 import { DataSourceBottomSheet } from "@/components/DataSourceBottomSheet";
 import { ItemCard } from "@/components/ItemCard";
@@ -63,10 +64,14 @@ export default function HomeScreen() {
   );
 
   return (
-    <SafeAreaView
+    <LinearGradient
+      colors={["#f5d0fe", "#fef3c7"]}
       className="flex-1"
-      edges={["top", "left", "right"]}
     >
+      <SafeAreaView
+        className="flex-1"
+        edges={["top", "left", "right"]}
+      >
       <SearchBar
         query={searchQuery}
         onQueryChanged={onSearchQueryChanged}
@@ -116,6 +121,7 @@ export default function HomeScreen() {
         selectedDataSource={selectedDataSource}
         onDataSourceSelected={onDataSourceSelected}
       />
-    </SafeAreaView>
+      </SafeAreaView>
+    </LinearGradient>
   );
 }

--- a/expo/components/ItemCard.tsx
+++ b/expo/components/ItemCard.tsx
@@ -1,8 +1,9 @@
-import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Text } from "@/components/ui/text";
 import { ItemUiModel } from "@/lib/types/uiModelTypes";
 import { Image } from "expo-image";
-import React from "react";
-import { TouchableOpacity } from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
+import React, { useEffect, useRef } from "react";
+import { Animated, StyleSheet, TouchableOpacity, View } from "react-native";
 
 interface ItemCardProps {
   item: ItemUiModel;
@@ -10,22 +11,47 @@ interface ItemCardProps {
 }
 
 export function ItemCard({ item, onPress }: ItemCardProps) {
+  const fadeAnim = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    Animated.timing(fadeAnim, {
+      toValue: 1,
+      duration: 300,
+      useNativeDriver: true,
+    }).start();
+  }, [fadeAnim]);
+
   return (
     <TouchableOpacity
       className="w-1/2 flex-1 p-2"
       onPress={() => onPress(item)}
     >
-      <Card>
-        <Image
-          source={{ uri: item.imageUrl }}
-          style={{ width: "100%", height: 150 }}
-          contentFit="cover"
-        />
-        <CardHeader>
-          <CardTitle className="line-clamp-1">{item.name}</CardTitle>
-          <CardDescription className="line-clamp-1">{item.cardCaption}</CardDescription>
-        </CardHeader>
-      </Card>
+      <Animated.View
+        style={{ opacity: fadeAnim }}
+        className="overflow-hidden rounded-2xl shadow-lg"
+      >
+        <View className="relative">
+          <Image
+            source={{ uri: item.imageUrl }}
+            style={{ width: '100%', height: 150 }}
+            contentFit="cover"
+          />
+          <LinearGradient
+            colors={["transparent", "rgba(0,0,0,0.6)"]}
+            style={StyleSheet.absoluteFill}
+          />
+          <View className="absolute bottom-0 left-0 right-0 p-2">
+            <Text className="text-base font-bold text-white">
+              {item.name}
+            </Text>
+            {item.cardCaption ? (
+              <Text className="text-xs text-gray-200">
+                {item.cardCaption}
+              </Text>
+            ) : null}
+          </View>
+        </View>
+      </Animated.View>
     </TouchableOpacity>
   );
 }

--- a/expo/components/ItemDetails.tsx
+++ b/expo/components/ItemDetails.tsx
@@ -30,6 +30,11 @@ export function ItemDetails({ item }: { item: ItemUiModel }) {
             style={{ flex: 1 }}
           />
         </View>
+        <View style={{ position: "absolute", bottom: 16, left: 16, right: 16 }}>
+          <Text className="text-2xl font-bold text-white">
+            {item.name}
+          </Text>
+        </View>
       </View>
 
       <View className="relative z-10 -mt-6 rounded-t-3xl bg-background">

--- a/expo/components/SearchBar.tsx
+++ b/expo/components/SearchBar.tsx
@@ -32,7 +32,7 @@ export const SearchBar = ({
 
   return (
     <View className="m-4 flex-row items-stretch gap-x-2">
-      <View className="flex-1 flex-row items-center rounded-lg border bg-card px-4 py-2">
+      <View className="flex-1 flex-row items-center overflow-hidden rounded-full border bg-card/70 px-4 py-2 shadow-md">
         <TextInput
           ref={textInputRef}
           className="flex-1 text-card-foreground placeholder:text-card-foreground"
@@ -58,7 +58,7 @@ export const SearchBar = ({
       </View>
       <TouchableOpacity
         onPress={onFilterButtonClicked}
-        className="flex aspect-square items-center justify-center rounded-lg border bg-card"
+        className="flex aspect-square items-center justify-center rounded-full border bg-card/70 shadow-md"
       >
         <Ionicons
           name="filter"


### PR DESCRIPTION
## Summary
- redesign `ItemCard` with gradient overlay and fade-in animation
- style the search bar with rounded corners and shadows
- wrap the home screen in a gradient background
- overlay item name on the details hero image

## Testing
- `npm run lint` *(fails: expo not installed)*
- `npx tsc -p expo/tsconfig.json --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_b_685b14db96b08321be04ef046da5dacd