### PR TITLE
Enhance Expo UI with gradients

### DIFF
--- a/expo/app/index.tsx
+++ b/expo/app/index.tsx
@@ -11,6 +11,7 @@ import {
   View,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+import { LinearGradient } from "expo-linear-gradient";
 
 import { DataSourceBottomSheet } from "@/components/DataSourceBottomSheet";
 import { ItemCard } from "@/components/ItemCard";
@@ -63,10 +64,14 @@ export default function HomeScreen() {
   );
 
   return (
-    <SafeAreaView
-      className="flex-1"
-      edges={["top", "left", "right"]}
+    <LinearGradient
+      colors={[colors.primary, colors.background]}
+      style={{ flex: 1 }}
     >
+      <SafeAreaView
+        className="flex-1"
+        edges={["top", "left", "right"]}
+      >
       <SearchBar
         query={searchQuery}
         onQueryChanged={onSearchQueryChanged}
@@ -116,6 +121,7 @@ export default function HomeScreen() {
         selectedDataSource={selectedDataSource}
         onDataSourceSelected={onDataSourceSelected}
       />
-    </SafeAreaView>
+      </SafeAreaView>
+    </LinearGradient>
   );
 }

--- a/expo/components/ItemCard.tsx
+++ b/expo/components/ItemCard.tsx
@@ -1,8 +1,10 @@
-import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card } from "@/components/ui/card";
+import { Text } from "@/components/ui/text";
 import { ItemUiModel } from "@/lib/types/uiModelTypes";
 import { Image } from "expo-image";
+import { LinearGradient } from "expo-linear-gradient";
 import React from "react";
-import { TouchableOpacity } from "react-native";
+import { TouchableOpacity, View } from "react-native";
 
 interface ItemCardProps {
   item: ItemUiModel;
@@ -15,16 +17,28 @@ export function ItemCard({ item, onPress }: ItemCardProps) {
       className="w-1/2 flex-1 p-2"
       onPress={() => onPress(item)}
     >
-      <Card>
-        <Image
-          source={{ uri: item.imageUrl }}
-          style={{ width: "100%", height: 150 }}
-          contentFit="cover"
-        />
-        <CardHeader>
-          <CardTitle className="line-clamp-1">{item.name}</CardTitle>
-          <CardDescription className="line-clamp-1">{item.cardCaption}</CardDescription>
-        </CardHeader>
+      <Card className="overflow-hidden rounded-xl shadow-lg">
+        <View className="relative">
+          <Image
+            source={{ uri: item.imageUrl }}
+            style={{ width: "100%", height: 150 }}
+            contentFit="cover"
+            transition={300}
+          />
+          <LinearGradient
+            colors={["transparent", "rgba(0,0,0,0.6)"]}
+            className="absolute bottom-0 left-0 right-0 px-3 py-2"
+          >
+            <Text className="text-base font-semibold text-white line-clamp-1">
+              {item.name}
+            </Text>
+            {item.cardCaption ? (
+              <Text className="text-xs text-white opacity-80 line-clamp-1">
+                {item.cardCaption}
+              </Text>
+            ) : null}
+          </LinearGradient>
+        </View>
       </Card>
     </TouchableOpacity>
   );

--- a/expo/components/ItemDetails.tsx
+++ b/expo/components/ItemDetails.tsx
@@ -22,13 +22,17 @@ export function ItemDetails({ item }: { item: ItemUiModel }) {
           source={{ uri: item.imageUrl }}
           style={{ width: "100%", height: "100%" }}
           contentFit="cover"
+          transition={300}
         />
 
-        <View style={{ position: "absolute", bottom: 0, left: 0, right: 0, height: "30%" }}>
+        <View style={{ position: "absolute", bottom: 0, left: 0, right: 0, height: "40%" }}>
           <LinearGradient
-            colors={["transparent", "rgba(0,0,0,0.4)"]}
+            colors={["transparent", "rgba(0,0,0,0.6)"]}
             style={{ flex: 1 }}
           />
+        </View>
+        <View className="absolute bottom-0 left-0 right-0 p-4">
+          <Text className="text-2xl font-bold text-white">{item.name}</Text>
         </View>
       </View>
 


### PR DESCRIPTION
## Summary
- give the Expo app a simple gradient background
- redesign the item cards with an image overlay gradient
- show the item title over the hero image on the detail screen

## Testing
- `npm run lint` *(fails: `expo` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685b14db96b08321be04ef046da5dacd