### PR TITLE
add vertical feed

### DIFF
--- a/expo/app/details/[id].tsx
+++ b/expo/app/details/[id].tsx
@@ -1,7 +1,6 @@
 import { FullScreenErrorView } from "@/components/FullScreenErrorView";
 import { ItemDetails } from "@/components/ItemDetails";
 import { useItemByIdQuery } from "@/lib/queries/useItemsQuery";
-import { shareItem } from "@/lib/services/shareService";
 import { DataSourceType } from "@/lib/ui/uiModelTypes";
 import { useTheme } from "@react-navigation/native";
 import { useLocalSearchParams } from "expo-router";
@@ -27,12 +26,7 @@ export default function DetailsScreen() {
     }
 
     if (item) {
-      return (
-        <ItemDetails
-          item={item}
-          onShare={() => shareItem(item.imageUrl, item.name)}
-        />
-      );
+      return <ItemDetails item={item} />;
     } else {
       return <FullScreenErrorView />;
     }

--- a/expo/app/index.tsx
+++ b/expo/app/index.tsx
@@ -1,13 +1,16 @@
 import { useItemsQuery } from "@/lib/queries/useItemsQuery";
 import { useAppStore } from "@/lib/store/appStore";
-import React, { useMemo } from "react";
+import * as ScreenOrientation from "expo-screen-orientation";
+import React, { useEffect, useMemo } from "react";
 import { ActivityIndicator, RefreshControl, View } from "react-native";
+import Animated, { FadeIn, FadeOut } from "react-native-reanimated";
 import { SafeAreaView, useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { DataSourceBottomSheet } from "@/components/DataSourceBottomSheet";
 import { EmptyView } from "@/components/EmptyView";
 import { ItemCard } from "@/components/ItemCard";
 import { SearchBar } from "@/components/SearchBar";
+import { VerticalFeed } from "@/components/VerticalFeed";
 import { useColumns } from "@/lib/hooks/useColumns";
 import { useTheme } from "@react-navigation/native";
 import { FlashList } from "@shopify/flash-list";
@@ -15,6 +18,19 @@ import { FlashList } from "@shopify/flash-list";
 export default function HomeScreen() {
   const searchQuery = useAppStore((state) => state.searchQuery);
   const selectedDataSource = useAppStore((state) => state.selectedDataSource);
+  const viewMode = useAppStore((state) => state.viewMode);
+
+  useEffect(() => {
+    const setOrientation = async () => {
+      if (viewMode === "feed") {
+        await ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.PORTRAIT_UP);
+      } else {
+        await ScreenOrientation.unlockAsync();
+      }
+    };
+
+    setOrientation();
+  }, [viewMode]);
 
   const { items, isLoading, isRefetching, isFetching, isFetchingNextPage, loadMoreItems, refetch } =
     useItemsQuery(selectedDataSource, searchQuery);
@@ -24,48 +40,71 @@ export default function HomeScreen() {
   const numColumns = useColumns();
   const listKey = useMemo(() => `list-${selectedDataSource}`, [selectedDataSource]);
 
+  const fadeInAnimation = FadeIn.duration(300);
+  const fadeOutAnimation = FadeOut.duration(200);
+
   return (
     <SafeAreaView
       style={{ flex: 1 }}
-      edges={["top", "left", "right"]}
+      edges={viewMode === "grid" ? ["top", "left", "right"] : []}
     >
-      <SearchBar />
+      {viewMode === "grid" && <SearchBar />}
 
       {isLoading && items.length === 0 ? (
         <FullscreenLoader />
-      ) : (
-        <FlashList
-          key={listKey}
-          data={items}
-          renderItem={({ item }) => <ItemCard item={item} />}
-          numColumns={numColumns}
-          contentContainerStyle={{ paddingHorizontal: 8, paddingBottom: insets.bottom }}
-          estimatedItemSize={200}
-          showsVerticalScrollIndicator={false}
-          refreshControl={
-            <RefreshControl
-              tintColor={colors.text}
-              progressBackgroundColor={colors.card}
-              colors={[colors.text]}
-              refreshing={isRefetching}
-              onRefresh={refetch}
-            />
-          }
-          onEndReached={loadMoreItems}
-          onEndReachedThreshold={2}
-          ListFooterComponent={isFetchingNextPage ? <FooterLoader /> : null}
-          ListEmptyComponent={
-            !isFetching ? (
-              <EmptyView
-                icon="search-outline"
-                title="No items found"
-                description="Try adjusting your search or data source"
+      ) : viewMode === "grid" ? (
+        <Animated.View
+          key="grid"
+          style={{ flex: 1 }}
+          entering={fadeInAnimation}
+          exiting={fadeOutAnimation}
+        >
+          <FlashList
+            key={listKey}
+            data={items}
+            renderItem={({ item }) => <ItemCard item={item} />}
+            numColumns={numColumns}
+            contentContainerStyle={{ paddingHorizontal: 8, paddingBottom: insets.bottom }}
+            estimatedItemSize={200}
+            showsVerticalScrollIndicator={false}
+            refreshControl={
+              <RefreshControl
+                tintColor={colors.text}
+                progressBackgroundColor={colors.card}
+                colors={[colors.text]}
+                refreshing={isRefetching}
+                onRefresh={refetch}
               />
-            ) : null
-          }
-          removeClippedSubviews
-          keyboardDismissMode="on-drag"
-        />
+            }
+            onEndReached={loadMoreItems}
+            onEndReachedThreshold={2}
+            ListFooterComponent={isFetchingNextPage ? <FooterLoader /> : null}
+            ListEmptyComponent={
+              !isFetching ? (
+                <EmptyView
+                  icon="search-outline"
+                  title="No items found"
+                  description="Try adjusting your search or data source"
+                />
+              ) : null
+            }
+            removeClippedSubviews
+            keyboardDismissMode="on-drag"
+          />
+        </Animated.View>
+      ) : (
+        <Animated.View
+          key="feed"
+          style={{ flex: 1 }}
+          entering={fadeInAnimation}
+          exiting={fadeOutAnimation}
+        >
+          <VerticalFeed
+            items={items}
+            onEndReached={loadMoreItems}
+            ListFooterComponent={isFetchingNextPage ? <FooterLoader /> : null}
+          />
+        </Animated.View>
       )}
 
       <DataSourceBottomSheet />

--- a/expo/app/index.tsx
+++ b/expo/app/index.tsx
@@ -48,7 +48,7 @@ export default function HomeScreen() {
       style={{ flex: 1 }}
       edges={viewMode === "grid" ? ["top", "left", "right"] : []}
     >
-      {viewMode === "grid" && <SearchBar />}
+      {viewMode === "grid" && <SearchBar hasItems={items.length > 0} />}
 
       {isLoading && items.length === 0 ? (
         <FullscreenLoader />

--- a/expo/app/index.tsx
+++ b/expo/app/index.tsx
@@ -100,6 +100,7 @@ export default function HomeScreen() {
           exiting={fadeOutAnimation}
         >
           <VerticalFeed
+            listKey={listKey}
             items={items}
             onEndReached={loadMoreItems}
             ListFooterComponent={isFetchingNextPage ? <FooterLoader /> : null}

--- a/expo/components/FullScreenItemCard.tsx
+++ b/expo/components/FullScreenItemCard.tsx
@@ -1,12 +1,12 @@
+import { IconButton } from "@/components/IconButton";
 import { useAppStore } from "@/lib/store/appStore";
 import { ItemUiModel } from "@/lib/ui/uiModelTypes";
-import { Ionicons } from "@expo/vector-icons";
 import { useTheme } from "@react-navigation/native";
 import { Image } from "expo-image";
 import { LinearGradient } from "expo-linear-gradient";
 import { useRouter } from "expo-router";
 import React from "react";
-import { Dimensions, Text, TouchableOpacity, View } from "react-native";
+import { Dimensions, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 interface FullScreenItemCardProps {
@@ -21,8 +21,6 @@ export function FullScreenItemCard({ item }: FullScreenItemCardProps) {
 
   const isFavoriteItem = useAppStore((state) => state.isFavorite(item.id));
   const toggleFavorite = useAppStore((state) => state.toggleFavorite);
-  const toggleViewMode = useAppStore((state) => state.toggleViewMode);
-  const onDataSourceButtonClicked = useAppStore((state) => state.onDataSourceButtonClicked);
 
   return (
     <View
@@ -53,12 +51,6 @@ export function FullScreenItemCard({ item }: FullScreenItemCardProps) {
         }}
       />
 
-      <TopControls
-        insets={insets}
-        toggleViewMode={toggleViewMode}
-        onDataSourceButtonClicked={onDataSourceButtonClicked}
-      />
-
       <SideControls
         insets={insets}
         isFavoriteItem={isFavoriteItem}
@@ -75,40 +67,6 @@ export function FullScreenItemCard({ item }: FullScreenItemCardProps) {
       <ItemInfo
         item={item}
         insets={insets}
-      />
-    </View>
-  );
-}
-
-function TopControls({
-  insets,
-  toggleViewMode,
-  onDataSourceButtonClicked,
-}: {
-  insets: { top: number };
-  toggleViewMode: () => void;
-  onDataSourceButtonClicked: () => void;
-}) {
-  return (
-    <View
-      style={{
-        position: "absolute",
-        top: insets.top + 16,
-        left: 16,
-        right: 16,
-        flexDirection: "row",
-        justifyContent: "space-between",
-        alignItems: "center",
-      }}
-    >
-      <IconButton
-        onPress={toggleViewMode}
-        iconName="apps"
-      />
-
-      <IconButton
-        onPress={onDataSourceButtonClicked}
-        iconName="options-outline"
       />
     </View>
   );
@@ -187,35 +145,5 @@ function ItemInfo({ item, insets }: { item: ItemUiModel; insets: { bottom: numbe
         </Text>
       )}
     </View>
-  );
-}
-
-function IconButton({
-  onPress,
-  iconName,
-  color = "white",
-}: {
-  onPress: () => void;
-  iconName: keyof typeof Ionicons.glyphMap;
-  color?: string;
-}) {
-  return (
-    <TouchableOpacity
-      onPress={onPress}
-      style={{
-        backgroundColor: "rgba(0,0,0,0.3)",
-        borderRadius: 25,
-        width: 50,
-        height: 50,
-        alignItems: "center",
-        justifyContent: "center",
-      }}
-    >
-      <Ionicons
-        name={iconName}
-        size={24}
-        color={color}
-      />
-    </TouchableOpacity>
   );
 }

--- a/expo/components/FullScreenItemCard.tsx
+++ b/expo/components/FullScreenItemCard.tsx
@@ -1,4 +1,5 @@
 import { IconButton } from "@/components/IconButton";
+import { shareItem } from "@/lib/services/shareService";
 import { useAppStore } from "@/lib/store/appStore";
 import { ItemUiModel } from "@/lib/ui/uiModelTypes";
 import { useTheme } from "@react-navigation/native";
@@ -9,18 +10,8 @@ import React from "react";
 import { Dimensions, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
-interface FullScreenItemCardProps {
-  item: ItemUiModel;
-}
-
-export function FullScreenItemCard({ item }: FullScreenItemCardProps) {
-  const router = useRouter();
-  const { colors } = useTheme();
-  const insets = useSafeAreaInsets();
+export function FullScreenItemCard({ item }: { item: ItemUiModel }) {
   const { width, height } = Dimensions.get("window");
-
-  const isFavoriteItem = useAppStore((state) => state.isFavorite(item.id));
-  const toggleFavorite = useAppStore((state) => state.toggleFavorite);
 
   return (
     <View
@@ -51,40 +42,19 @@ export function FullScreenItemCard({ item }: FullScreenItemCardProps) {
         }}
       />
 
-      <SideControls
-        insets={insets}
-        isFavoriteItem={isFavoriteItem}
-        colors={colors}
-        handleFavoritePress={() => toggleFavorite(item)}
-        handlePress={() =>
-          router.push({
-            pathname: "/details/[id]",
-            params: { id: item.id, dataSource: item.dataSource },
-          })
-        }
-      />
-
-      <ItemInfo
-        item={item}
-        insets={insets}
-      />
+      <SideControls item={item} />
+      <ItemInfo item={item} />
     </View>
   );
 }
 
-function SideControls({
-  insets,
-  isFavoriteItem,
-  colors,
-  handleFavoritePress,
-  handlePress,
-}: {
-  insets: { bottom: number };
-  isFavoriteItem: boolean;
-  colors: { primary: string };
-  handleFavoritePress: () => void;
-  handlePress: () => void;
-}) {
+function SideControls({ item }: { item: ItemUiModel }) {
+  const router = useRouter();
+  const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
+  const isFavoriteItem = useAppStore((state) => state.isFavorite(item.id));
+  const toggleFavorite = useAppStore((state) => state.toggleFavorite);
+
   return (
     <View
       style={{
@@ -96,20 +66,32 @@ function SideControls({
       }}
     >
       <IconButton
-        onPress={handleFavoritePress}
+        onPress={() => toggleFavorite(item)}
         iconName={isFavoriteItem ? "heart" : "heart-outline"}
         color={isFavoriteItem ? colors.primary : "white"}
       />
 
       <IconButton
-        onPress={handlePress}
+        onPress={() => shareItem(item)}
+        iconName="share-social-outline"
+      />
+
+      <IconButton
+        onPress={() =>
+          router.push({
+            pathname: "/details/[id]",
+            params: { id: item.id, dataSource: item.dataSource },
+          })
+        }
         iconName="open-outline"
       />
     </View>
   );
 }
 
-function ItemInfo({ item, insets }: { item: ItemUiModel; insets: { bottom: number } }) {
+function ItemInfo({ item }: { item: ItemUiModel }) {
+  const insets = useSafeAreaInsets();
+
   return (
     <View
       style={{

--- a/expo/components/FullScreenItemCard.tsx
+++ b/expo/components/FullScreenItemCard.tsx
@@ -1,0 +1,221 @@
+import { useAppStore } from "@/lib/store/appStore";
+import { ItemUiModel } from "@/lib/ui/uiModelTypes";
+import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "@react-navigation/native";
+import { Image } from "expo-image";
+import { LinearGradient } from "expo-linear-gradient";
+import { useRouter } from "expo-router";
+import React from "react";
+import { Dimensions, Text, TouchableOpacity, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+interface FullScreenItemCardProps {
+  item: ItemUiModel;
+}
+
+export function FullScreenItemCard({ item }: FullScreenItemCardProps) {
+  const router = useRouter();
+  const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
+  const { width, height } = Dimensions.get("window");
+
+  const isFavoriteItem = useAppStore((state) => state.isFavorite(item.id));
+  const toggleFavorite = useAppStore((state) => state.toggleFavorite);
+  const toggleViewMode = useAppStore((state) => state.toggleViewMode);
+  const onFilterButtonClicked = useAppStore((state) => state.onFilterButtonClicked);
+
+  return (
+    <View
+      style={{
+        width,
+        height,
+        position: "relative",
+      }}
+    >
+      <Image
+        source={item.highResImageUrl}
+        style={{
+          width: "100%",
+          height: "100%",
+        }}
+        contentFit="cover"
+        priority="high"
+      />
+
+      <LinearGradient
+        colors={["transparent", "transparent", "rgba(0,0,0,0.8)"]}
+        style={{
+          position: "absolute",
+          left: 0,
+          right: 0,
+          bottom: 0,
+          height: height * 0.4,
+        }}
+      />
+
+      <TopControls
+        insets={insets}
+        toggleViewMode={toggleViewMode}
+        onFilterButtonClicked={onFilterButtonClicked}
+      />
+
+      <SideControls
+        insets={insets}
+        isFavoriteItem={isFavoriteItem}
+        colors={colors}
+        handleFavoritePress={() => toggleFavorite(item)}
+        handlePress={() =>
+          router.push({
+            pathname: "/details/[id]",
+            params: { id: item.id, dataSource: item.dataSource },
+          })
+        }
+      />
+
+      <ItemInfo
+        item={item}
+        insets={insets}
+      />
+    </View>
+  );
+}
+
+function TopControls({
+  insets,
+  toggleViewMode,
+  onFilterButtonClicked,
+}: {
+  insets: { top: number };
+  toggleViewMode: () => void;
+  onFilterButtonClicked: () => void;
+}) {
+  return (
+    <View
+      style={{
+        position: "absolute",
+        top: insets.top + 16,
+        left: 16,
+        right: 16,
+        flexDirection: "row",
+        justifyContent: "space-between",
+        alignItems: "center",
+      }}
+    >
+      <IconButton
+        onPress={toggleViewMode}
+        iconName="apps"
+      />
+
+      <IconButton
+        onPress={onFilterButtonClicked}
+        iconName="options-outline"
+      />
+    </View>
+  );
+}
+
+function SideControls({
+  insets,
+  isFavoriteItem,
+  colors,
+  handleFavoritePress,
+  handlePress,
+}: {
+  insets: { bottom: number };
+  isFavoriteItem: boolean;
+  colors: { primary: string };
+  handleFavoritePress: () => void;
+  handlePress: () => void;
+}) {
+  return (
+    <View
+      style={{
+        position: "absolute",
+        right: 16,
+        bottom: insets.bottom + 24,
+        alignItems: "center",
+        gap: 24,
+      }}
+    >
+      <IconButton
+        onPress={handleFavoritePress}
+        iconName={isFavoriteItem ? "heart" : "heart-outline"}
+        color={isFavoriteItem ? colors.primary : "white"}
+      />
+
+      <IconButton
+        onPress={handlePress}
+        iconName="open-outline"
+      />
+    </View>
+  );
+}
+
+function ItemInfo({ item, insets }: { item: ItemUiModel; insets: { bottom: number } }) {
+  return (
+    <View
+      style={{
+        position: "absolute",
+        left: 16,
+        right: 80,
+        bottom: insets.bottom + 24,
+      }}
+    >
+      <Text
+        style={{
+          fontSize: 24,
+          fontWeight: "700",
+          color: "white",
+          marginBottom: 8,
+          letterSpacing: 0.5,
+        }}
+        numberOfLines={2}
+      >
+        {item.name}
+      </Text>
+      {item.cardCaption && (
+        <Text
+          style={{
+            fontSize: 16,
+            color: "white",
+            opacity: 0.9,
+            lineHeight: 22,
+          }}
+          numberOfLines={3}
+        >
+          {item.cardCaption}
+        </Text>
+      )}
+    </View>
+  );
+}
+
+function IconButton({
+  onPress,
+  iconName,
+  color = "white",
+}: {
+  onPress: () => void;
+  iconName: keyof typeof Ionicons.glyphMap;
+  color?: string;
+}) {
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      style={{
+        backgroundColor: "rgba(0,0,0,0.3)",
+        borderRadius: 25,
+        width: 50,
+        height: 50,
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <Ionicons
+        name={iconName}
+        size={24}
+        color={color}
+      />
+    </TouchableOpacity>
+  );
+}

--- a/expo/components/FullScreenItemCard.tsx
+++ b/expo/components/FullScreenItemCard.tsx
@@ -22,7 +22,7 @@ export function FullScreenItemCard({ item }: FullScreenItemCardProps) {
   const isFavoriteItem = useAppStore((state) => state.isFavorite(item.id));
   const toggleFavorite = useAppStore((state) => state.toggleFavorite);
   const toggleViewMode = useAppStore((state) => state.toggleViewMode);
-  const onFilterButtonClicked = useAppStore((state) => state.onFilterButtonClicked);
+  const onDataSourceButtonClicked = useAppStore((state) => state.onDataSourceButtonClicked);
 
   return (
     <View
@@ -56,7 +56,7 @@ export function FullScreenItemCard({ item }: FullScreenItemCardProps) {
       <TopControls
         insets={insets}
         toggleViewMode={toggleViewMode}
-        onFilterButtonClicked={onFilterButtonClicked}
+        onDataSourceButtonClicked={onDataSourceButtonClicked}
       />
 
       <SideControls
@@ -83,11 +83,11 @@ export function FullScreenItemCard({ item }: FullScreenItemCardProps) {
 function TopControls({
   insets,
   toggleViewMode,
-  onFilterButtonClicked,
+  onDataSourceButtonClicked,
 }: {
   insets: { top: number };
   toggleViewMode: () => void;
-  onFilterButtonClicked: () => void;
+  onDataSourceButtonClicked: () => void;
 }) {
   return (
     <View
@@ -107,7 +107,7 @@ function TopControls({
       />
 
       <IconButton
-        onPress={onFilterButtonClicked}
+        onPress={onDataSourceButtonClicked}
         iconName="options-outline"
       />
     </View>

--- a/expo/components/IconButton.tsx
+++ b/expo/components/IconButton.tsx
@@ -1,0 +1,31 @@
+import { Ionicons } from "@expo/vector-icons";
+import React from "react";
+import { TouchableOpacity } from "react-native";
+
+interface IconButtonProps {
+  onPress: () => void;
+  iconName: keyof typeof Ionicons.glyphMap;
+  color?: string;
+}
+
+export function IconButton({ onPress, iconName, color = "white" }: IconButtonProps) {
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      style={{
+        backgroundColor: "rgba(0,0,0,0.3)",
+        borderRadius: 25,
+        width: 50,
+        height: 50,
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <Ionicons
+        name={iconName}
+        size={24}
+        color={color}
+      />
+    </TouchableOpacity>
+  );
+}

--- a/expo/components/ItemDetails.tsx
+++ b/expo/components/ItemDetails.tsx
@@ -1,3 +1,4 @@
+import { shareItem } from "@/lib/services/shareService";
 import { useAppStore } from "@/lib/store/appStore";
 import { ItemUiModel } from "@/lib/ui/uiModelTypes";
 import { Ionicons } from "@expo/vector-icons";
@@ -12,7 +13,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 const { width } = Dimensions.get("window");
 const HERO_HEIGHT = width * 0.75;
 
-export function ItemDetails({ item, onShare }: { item: ItemUiModel; onShare: () => void }) {
+export function ItemDetails({ item }: { item: ItemUiModel }) {
   return (
     <View style={{ flex: 1 }}>
       <ScrollView
@@ -22,22 +23,27 @@ export function ItemDetails({ item, onShare }: { item: ItemUiModel; onShare: () 
         <HeroImage item={item} />
         <MainContent item={item} />
       </ScrollView>
-      <HeaderButtons
-        item={item}
-        onShare={onShare}
-      />
+      <HeaderButtons item={item} />
     </View>
   );
 }
 
-function HeaderButtons({ item, onShare }: { item: ItemUiModel; onShare: () => void }) {
+function HeaderButtons({ item }: { item: ItemUiModel }) {
   const insets = useSafeAreaInsets();
   const router = useRouter();
   const { colors } = useTheme();
   const isFavoriteItem = useAppStore((state) => state.isFavorite(item.id));
   const toggleFavorite = useAppStore((state) => state.toggleFavorite);
 
-  const button = (icon: keyof typeof Ionicons.glyphMap, color: string, onPress: () => void) => {
+  const button = ({
+    icon,
+    color,
+    onPress,
+  }: {
+    icon: keyof typeof Ionicons.glyphMap;
+    color: string;
+    onPress: () => void;
+  }) => {
     return (
       <TouchableOpacity
         onPress={onPress}
@@ -76,14 +82,22 @@ function HeaderButtons({ item, onShare }: { item: ItemUiModel; onShare: () => vo
         alignItems: "center",
       }}
     >
-      {button("close", colors.text, () => router.back())}
+      {button({
+        icon: "close",
+        color: colors.text,
+        onPress: () => router.back(),
+      })}
       <View style={{ flexDirection: "row", gap: 12 }}>
-        {button(
-          isFavoriteItem ? "heart" : "heart-outline",
-          isFavoriteItem ? colors.primary : colors.text,
-          () => toggleFavorite(item),
-        )}
-        {button("share-outline", colors.text, onShare)}
+        {button({
+          icon: isFavoriteItem ? "heart" : "heart-outline",
+          color: isFavoriteItem ? colors.primary : colors.text,
+          onPress: () => toggleFavorite(item),
+        })}
+        {button({
+          icon: "share-social-outline",
+          color: colors.text,
+          onPress: () => shareItem(item),
+        })}
       </View>
     </View>
   );

--- a/expo/components/SearchBar.tsx
+++ b/expo/components/SearchBar.tsx
@@ -5,7 +5,11 @@ import { useRouter } from "expo-router";
 import { useEffect, useRef } from "react";
 import { TextInput, TouchableOpacity, View } from "react-native";
 
-export const SearchBar = () => {
+interface SearchBarProps {
+  hasItems?: boolean;
+}
+
+export const SearchBar = ({ hasItems = true }: SearchBarProps) => {
   const router = useRouter();
   const textInputRef = useRef<TextInput | null>(null);
   const { colors } = useTheme();
@@ -15,39 +19,9 @@ export const SearchBar = () => {
   const onSearchQueryChanged = useAppStore((state) => state.onSearchQueryChanged);
   const onSearchFocused = useAppStore((state) => state.onSearchFocused);
   const onClearButtonClicked = useAppStore((state) => state.onClearButtonClicked);
-  const onFilterButtonClicked = useAppStore((state) => state.onFilterButtonClicked);
+  const onDataSourceButtonClicked = useAppStore((state) => state.onDataSourceButtonClicked);
   const isBottomSheetOpen = useAppStore((state) => state.isBottomSheetOpen);
   const toggleViewMode = useAppStore((state) => state.toggleViewMode);
-
-  const createActionButton = (
-    onPress: () => void,
-    icon: keyof typeof Ionicons.glyphMap,
-    isPrimary: boolean,
-  ) => (
-    <TouchableOpacity
-      onPress={onPress}
-      style={[
-        {
-          alignItems: "center",
-          justifyContent: "center",
-          borderRadius: 16,
-          backgroundColor: isPrimary ? colors.primary : colors.card,
-          width: 48,
-          height: 48,
-          shadowOffset: { width: 0, height: 4 },
-          shadowOpacity: 0.2,
-          shadowRadius: 8,
-          elevation: 5,
-        },
-      ]}
-    >
-      <Ionicons
-        name={icon}
-        size={20}
-        color={isPrimary ? "white" : colors.primary}
-      />
-    </TouchableOpacity>
-  );
 
   useEffect(() => {
     if (isSearchFocused) {
@@ -117,9 +91,69 @@ export const SearchBar = () => {
         </TouchableOpacity>
       </View>
 
-      {createActionButton(() => router.push("/favorites"), "heart", false)}
-      {createActionButton(toggleViewMode, "apps", false)}
-      {createActionButton(onFilterButtonClicked, "options-outline", true)}
+      <ActionButton
+        onPress={() => router.push("/favorites")}
+        icon="heart"
+        isPrimary={false}
+        enabled={true}
+      />
+      <ActionButton
+        onPress={toggleViewMode}
+        icon="apps"
+        isPrimary={false}
+        enabled={hasItems}
+      />
+      <ActionButton
+        onPress={onDataSourceButtonClicked}
+        icon="options-outline"
+        isPrimary={true}
+        enabled={true}
+      />
     </View>
   );
 };
+
+function ActionButton({
+  onPress,
+  icon,
+  isPrimary,
+  enabled,
+}: {
+  onPress: () => void;
+  icon: keyof typeof Ionicons.glyphMap;
+  isPrimary: boolean;
+  enabled: boolean;
+}) {
+  const { colors } = useTheme();
+
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      disabled={!enabled}
+      style={[
+        {
+          alignItems: "center",
+          justifyContent: "center",
+          borderRadius: 16,
+          backgroundColor: isPrimary ? colors.primary : colors.card,
+          width: 48,
+          height: 48,
+          shadowOffset: { width: 0, height: 4 },
+          shadowOpacity: 0.2,
+          shadowRadius: 8,
+          elevation: 5,
+        },
+        !enabled && {
+          opacity: 0.5,
+          shadowOpacity: 0.1,
+        },
+      ]}
+    >
+      <Ionicons
+        name={icon}
+        size={20}
+        color={isPrimary ? "white" : colors.primary}
+      />
+    </TouchableOpacity>
+  );
+}

--- a/expo/components/SearchBar.tsx
+++ b/expo/components/SearchBar.tsx
@@ -9,7 +9,7 @@ export const SearchBar = () => {
   const router = useRouter();
   const textInputRef = useRef<TextInput | null>(null);
   const { colors } = useTheme();
-  
+
   const searchQuery = useAppStore((state) => state.searchQuery);
   const isSearchFocused = useAppStore((state) => state.isSearchFocused);
   const onSearchQueryChanged = useAppStore((state) => state.onSearchQueryChanged);
@@ -17,6 +17,7 @@ export const SearchBar = () => {
   const onClearButtonClicked = useAppStore((state) => state.onClearButtonClicked);
   const onFilterButtonClicked = useAppStore((state) => state.onFilterButtonClicked);
   const isBottomSheetOpen = useAppStore((state) => state.isBottomSheetOpen);
+  const toggleViewMode = useAppStore((state) => state.toggleViewMode);
 
   const createActionButton = (
     onPress: () => void,
@@ -117,6 +118,7 @@ export const SearchBar = () => {
       </View>
 
       {createActionButton(() => router.push("/favorites"), "heart", false)}
+      {createActionButton(toggleViewMode, "apps", false)}
       {createActionButton(onFilterButtonClicked, "options-outline", true)}
     </View>
   );

--- a/expo/components/SearchBar.tsx
+++ b/expo/components/SearchBar.tsx
@@ -5,11 +5,7 @@ import { useRouter } from "expo-router";
 import { useEffect, useRef } from "react";
 import { TextInput, TouchableOpacity, View } from "react-native";
 
-interface SearchBarProps {
-  hasItems?: boolean;
-}
-
-export const SearchBar = ({ hasItems = true }: SearchBarProps) => {
+export const SearchBar = ({ hasItems }: { hasItems: boolean }) => {
   const router = useRouter();
   const textInputRef = useRef<TextInput | null>(null);
   const { colors } = useTheme();

--- a/expo/components/SearchBar.tsx
+++ b/expo/components/SearchBar.tsx
@@ -95,7 +95,7 @@ export const SearchBar = ({ hasItems }: { hasItems: boolean }) => {
       />
       <ActionButton
         onPress={toggleViewMode}
-        icon="apps"
+        icon="reorder-four"
         isPrimary={false}
         enabled={hasItems}
       />

--- a/expo/components/VerticalFeed.tsx
+++ b/expo/components/VerticalFeed.tsx
@@ -1,34 +1,72 @@
 import { FullScreenItemCard } from "@/components/FullScreenItemCard";
+import { IconButton } from "@/components/IconButton";
+import { useAppStore } from "@/lib/store/appStore";
 import { ItemUiModel } from "@/lib/ui/uiModelTypes";
 import React from "react";
-import { Dimensions, FlatList } from "react-native";
+import { Dimensions, FlatList, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 interface VerticalFeedProps {
+  listKey: string;
   items: ItemUiModel[];
   onEndReached: () => void;
   ListFooterComponent?: React.ComponentType<any> | React.ReactElement | null;
 }
 
-export function VerticalFeed({ items, onEndReached, ListFooterComponent }: VerticalFeedProps) {
+export function VerticalFeed({
+  listKey,
+  items,
+  onEndReached,
+  ListFooterComponent,
+}: VerticalFeedProps) {
   const { height } = Dimensions.get("window");
+  const insets = useSafeAreaInsets();
+  const toggleViewMode = useAppStore((state) => state.toggleViewMode);
+  const onDataSourceButtonClicked = useAppStore((state) => state.onDataSourceButtonClicked);
+
   return (
-    <FlatList
-      data={items}
-      renderItem={({ item }) => <FullScreenItemCard item={item} />}
-      keyExtractor={(item) => item.id}
-      pagingEnabled
-      showsVerticalScrollIndicator={false}
-      snapToInterval={height}
-      snapToAlignment="start"
-      decelerationRate="fast"
-      onEndReached={onEndReached}
-      onEndReachedThreshold={2}
-      ListFooterComponent={ListFooterComponent}
-      getItemLayout={(_, index) => ({
-        length: height,
-        offset: height * index,
-        index,
-      })}
-    />
+    <View style={{ flex: 1 }}>
+      <FlatList
+        key={listKey}
+        data={items}
+        renderItem={({ item }) => <FullScreenItemCard item={item} />}
+        keyExtractor={(item) => item.id}
+        pagingEnabled
+        showsVerticalScrollIndicator={false}
+        snapToInterval={height}
+        snapToAlignment="start"
+        decelerationRate="fast"
+        onEndReached={onEndReached}
+        onEndReachedThreshold={2}
+        ListFooterComponent={ListFooterComponent}
+        getItemLayout={(_, index) => ({
+          length: height,
+          offset: height * index,
+          index,
+        })}
+      />
+
+      <View
+        style={{
+          position: "absolute",
+          top: insets.top + 16,
+          left: 16,
+          right: 16,
+          flexDirection: "row",
+          justifyContent: "space-between",
+          alignItems: "center",
+        }}
+      >
+        <IconButton
+          onPress={toggleViewMode}
+          iconName="apps"
+        />
+
+        <IconButton
+          onPress={onDataSourceButtonClicked}
+          iconName="options-outline"
+        />
+      </View>
+    </View>
   );
 }

--- a/expo/components/VerticalFeed.tsx
+++ b/expo/components/VerticalFeed.tsx
@@ -1,0 +1,34 @@
+import { FullScreenItemCard } from "@/components/FullScreenItemCard";
+import { ItemUiModel } from "@/lib/ui/uiModelTypes";
+import React from "react";
+import { Dimensions, FlatList } from "react-native";
+
+interface VerticalFeedProps {
+  items: ItemUiModel[];
+  onEndReached: () => void;
+  ListFooterComponent?: React.ComponentType<any> | React.ReactElement | null;
+}
+
+export function VerticalFeed({ items, onEndReached, ListFooterComponent }: VerticalFeedProps) {
+  const { height } = Dimensions.get("window");
+  return (
+    <FlatList
+      data={items}
+      renderItem={({ item }) => <FullScreenItemCard item={item} />}
+      keyExtractor={(item) => item.id}
+      pagingEnabled
+      showsVerticalScrollIndicator={false}
+      snapToInterval={height}
+      snapToAlignment="start"
+      decelerationRate="fast"
+      onEndReached={onEndReached}
+      onEndReachedThreshold={2}
+      ListFooterComponent={ListFooterComponent}
+      getItemLayout={(_, index) => ({
+        length: height,
+        offset: height * index,
+        index,
+      })}
+    />
+  );
+}

--- a/expo/lib/apis/artic/data.ts
+++ b/expo/lib/apis/artic/data.ts
@@ -32,6 +32,7 @@ const mapArticArtworkToItem = (artwork: ArticArtwork): ItemUiModel => {
   return {
     id: artwork.id.toString(),
     imageUrl: `https://artic.edu/iiif/2/${artwork.image_id}/full/200,/0/default.jpg`,
+    highResImageUrl: `https://artic.edu/iiif/2/${artwork.image_id}/full/800,/0/default.jpg`,
     name: artwork.title,
     cardCaption: artwork.artist_display || artwork.date_display,
     dataSource: "artic",

--- a/expo/lib/apis/giphy/data.ts
+++ b/expo/lib/apis/giphy/data.ts
@@ -38,6 +38,7 @@ const mapGiphyGifToItem = (gif: GiphyGif): ItemUiModel => {
   return {
     id: gif.id,
     imageUrl: gif.images.fixed_width.url,
+    highResImageUrl: gif.images.downsized?.url || gif.images.fixed_width.url,
     name: gif.title || "Untitled GIF",
     cardCaption: username !== "Unknown" ? `by ${username}` : undefined,
     dataSource: "giphy",

--- a/expo/lib/apis/giphy/types.ts
+++ b/expo/lib/apis/giphy/types.ts
@@ -19,6 +19,11 @@ export interface GiphyGif {
       width: string;
       height: string;
     };
+    downsized: {
+      url: string;
+      width: string;
+      height: string;
+    };
     original: {
       url: string;
       width: string;

--- a/expo/lib/apis/rick-and-morty/data.ts
+++ b/expo/lib/apis/rick-and-morty/data.ts
@@ -44,6 +44,7 @@ const mapRickAndMortyCharacterToItem = (character: RickAndMortyCharacter): ItemU
   return {
     id: character.id.toString(),
     imageUrl: character.image,
+    highResImageUrl: character.image,
     name: character.name,
     cardCaption: `${character.species}`,
     dataSource: "rick-and-morty",

--- a/expo/lib/services/shareService.ts
+++ b/expo/lib/services/shareService.ts
@@ -1,8 +1,12 @@
+import { ItemUiModel } from "@/lib/ui/uiModelTypes";
 import * as FileSystem from "expo-file-system";
 import * as Sharing from "expo-sharing";
 import { Alert, Platform } from "react-native";
 
-export async function shareItem(imageUrl: string, title: string): Promise<void> {
+export async function shareItem(item: ItemUiModel): Promise<void> {
+  const title = item.name;
+  const imageUrl = item.highResImageUrl;
+
   try {
     if (!(await Sharing.isAvailableAsync())) {
       Alert.alert("Sharing not available", "Sharing is not available on this device.");

--- a/expo/lib/store/appStore.ts
+++ b/expo/lib/store/appStore.ts
@@ -19,7 +19,7 @@ interface AppState {
   onSearchFocused: (isFocused: boolean) => void;
   onSearchQueryChanged: (query: string) => void;
   onClearButtonClicked: () => void;
-  onFilterButtonClicked: () => void;
+  onDataSourceButtonClicked: () => void;
 
   viewMode: ViewMode;
   toggleViewMode: () => void;
@@ -93,7 +93,7 @@ export const useAppStore = create<AppState>((set, get) => {
       set({ searchQuery: "", isSearchFocused: false });
     },
 
-    onFilterButtonClicked: () => {
+    onDataSourceButtonClicked: () => {
       set({
         isBottomSheetOpen: true,
         isSearchFocused: false,

--- a/expo/lib/store/appStore.ts
+++ b/expo/lib/store/appStore.ts
@@ -6,6 +6,8 @@ const DATA_SOURCE_STORAGE_KEY = "selected_data_source";
 const FAVORITES_STORAGE_KEY = "favorites";
 const DEFAULT_DATA_SOURCE: DataSourceType = "giphy";
 
+export type ViewMode = "grid" | "feed";
+
 interface AppState {
   initialize: () => Promise<void>;
 
@@ -18,6 +20,9 @@ interface AppState {
   onSearchQueryChanged: (query: string) => void;
   onClearButtonClicked: () => void;
   onFilterButtonClicked: () => void;
+
+  viewMode: ViewMode;
+  toggleViewMode: () => void;
 
   isBottomSheetOpen: boolean;
   onBottomSheetClosed: () => void;
@@ -32,6 +37,7 @@ export const useAppStore = create<AppState>((set, get) => {
     selectedDataSource: DEFAULT_DATA_SOURCE,
     searchQuery: "",
     isSearchFocused: false,
+    viewMode: "grid" as ViewMode,
     isBottomSheetOpen: false,
     favorites: [],
 
@@ -92,6 +98,11 @@ export const useAppStore = create<AppState>((set, get) => {
         isBottomSheetOpen: true,
         isSearchFocused: false,
       });
+    },
+
+    toggleViewMode: () => {
+      const { viewMode } = get();
+      set({ viewMode: viewMode === "grid" ? "feed" : "grid" });
     },
 
     onBottomSheetClosed: () => {

--- a/expo/lib/ui/uiModelTypes.ts
+++ b/expo/lib/ui/uiModelTypes.ts
@@ -3,6 +3,7 @@ export type DataSourceType = "rick-and-morty" | "giphy" | "artic";
 export interface ItemUiModel {
   id: string;
   imageUrl: string;
+  highResImageUrl: string;
   name: string;
   cardCaption?: string;
   detailsKeyValues: Array<{ key: string; value: string }>;

--- a/expo/package-lock.json
+++ b/expo/package-lock.json
@@ -23,6 +23,7 @@
         "expo-linear-gradient": "~14.1.5",
         "expo-linking": "~7.1.7",
         "expo-router": "~5.1.3",
+        "expo-screen-orientation": "~8.1.7",
         "expo-sharing": "~13.1.2",
         "expo-splash-screen": "~0.30.10",
         "expo-status-bar": "~2.2.3",
@@ -6488,6 +6489,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/expo-screen-orientation": {
+      "version": "8.1.7",
+      "resolved": "https://registry.npmjs.org/expo-screen-orientation/-/expo-screen-orientation-8.1.7.tgz",
+      "integrity": "sha512-nYwadYtdU6mMDk0MCHMPPPQtBoeFYJ2FspLRW+J35CMLqzE4nbpwGeiImfXzkvD94fpOCfI4KgLj5vGauC3pfA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-sharing": {

--- a/expo/package.json
+++ b/expo/package.json
@@ -36,7 +36,8 @@
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
     "react-native-web": "~0.20.0",
-    "zustand": "^5.0.2"
+    "zustand": "^5.0.2",
+    "expo-screen-orientation": "~8.1.7"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a toggle to switch between "grid" and "feed" view modes on the Home screen.
  * Added a full-screen item card with high-resolution images and interactive controls.
  * Implemented a vertical feed layout with smooth paging and snapping for full-screen browsing.
  * Added an icon button component for consistent interactive icons across the app.

* **Enhancements**
  * SearchBar now includes a button to toggle view modes and adapts based on item availability.
  * Items now support high-resolution images for improved visual quality.
  * Screen orientation automatically locks to portrait in "feed" mode and unlocks in "grid" mode.
  * Safe area handling and UI animations improved for smoother transitions between view modes.
  * Sharing functionality streamlined with share actions encapsulated within relevant components.

* **Bug Fixes**
  * Screen orientation is locked to portrait in "feed" mode and unlocked in "grid" mode for a better user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->